### PR TITLE
fix(webview): preserve login WebView state across rotation (#46)

### DIFF
--- a/app/src/main/java/com/kidozh/discuzhub/activities/WebViewLoginActivity.kt
+++ b/app/src/main/java/com/kidozh/discuzhub/activities/WebViewLoginActivity.kt
@@ -50,9 +50,19 @@ class WebViewLoginActivity : BaseStatusActivity() {
             layoutInflater
         )
         setContentView(binding!!.root)
-        configureIntentData()
+        configureIntentData(savedInstanceState)
         configureActionBar()
-        configureAlertDialog()
+        if (savedInstanceState == null) {
+            configureAlertDialog()
+        }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        // Issue #46: persist the login WebView so device rotation does
+        // not drop the user back at the initial login page after they
+        // have already navigated several screens deep.
+        binding?.loginByWebWebview?.saveState(outState)
     }
 
     fun configureAlertDialog() {

--- a/app/src/main/java/com/kidozh/discuzhub/activities/WebViewLoginActivity.kt
+++ b/app/src/main/java/com/kidozh/discuzhub/activities/WebViewLoginActivity.kt
@@ -63,18 +63,18 @@ class WebViewLoginActivity : BaseStatusActivity() {
             .show()
     }
 
-    fun configureIntentData(savedInstanceState: Bundle? = null) {
+    fun configureIntentData() {
         val intent = intent
         discuz = intent.getSerializableExtra(ConstUtils.PASS_BBS_ENTITY_KEY) as Discuz?
         if (discuz != null) {
             URLUtils.setBBS(discuz)
-            configureWebView(savedInstanceState)
+            configureWebView()
         } else {
             // judge whether from QQ
             if (Intent.ACTION_VIEW == intent.action && intent.data != null) {
                 val url = intent.data.toString()
                 Log.d(TAG, "Get QQ Login URL $url")
-                configureQQLoginWebview(url, savedInstanceState)
+                configureQQLoginWebview(url)
             }
         }
     }
@@ -91,15 +91,22 @@ class WebViewLoginActivity : BaseStatusActivity() {
         }
     }
 
-    fun configureWebView() {
+    fun configureWebView(savedInstanceState: Bundle? = null) {
         cookieWebViewClientInstance = CookieWebViewClient()
         Log.d(
             TAG, "login web url " + URLUtils.getLoginWebURL(
                 discuz!!
             )
         )
-        binding!!.loginByWebWebview.loadUrl(URLUtils.getLoginWebURL(discuz!!))
-        binding!!.loginByWebWebview.clearCache(true)
+        if (savedInstanceState != null) {
+            // Issue #46: rotation used to throw away the user's
+            // navigation history. Restore the saved WebView snapshot
+            // instead of reloading the initial login URL.
+            binding!!.loginByWebWebview.restoreState(savedInstanceState)
+        } else {
+            binding!!.loginByWebWebview.loadUrl(URLUtils.getLoginWebURL(discuz!!))
+            binding!!.loginByWebWebview.clearCache(true)
+        }
         val webSettings = binding!!.loginByWebWebview.settings
 
         // to allow authentication to use JS

--- a/app/src/main/java/com/kidozh/discuzhub/activities/WebViewLoginActivity.kt
+++ b/app/src/main/java/com/kidozh/discuzhub/activities/WebViewLoginActivity.kt
@@ -91,22 +91,15 @@ class WebViewLoginActivity : BaseStatusActivity() {
         }
     }
 
-    fun configureWebView(savedInstanceState: Bundle? = null) {
+    fun configureWebView() {
         cookieWebViewClientInstance = CookieWebViewClient()
         Log.d(
             TAG, "login web url " + URLUtils.getLoginWebURL(
                 discuz!!
             )
         )
-        if (savedInstanceState != null) {
-            // Issue #46: rotation used to throw away the user's
-            // navigation history. Restore the saved WebView snapshot
-            // instead of reloading the initial login URL.
-            binding!!.loginByWebWebview.restoreState(savedInstanceState)
-        } else {
-            binding!!.loginByWebWebview.loadUrl(URLUtils.getLoginWebURL(discuz!!))
-            binding!!.loginByWebWebview.clearCache(true)
-        }
+        binding!!.loginByWebWebview.loadUrl(URLUtils.getLoginWebURL(discuz!!))
+        binding!!.loginByWebWebview.clearCache(true)
         val webSettings = binding!!.loginByWebWebview.settings
 
         // to allow authentication to use JS
@@ -126,10 +119,14 @@ class WebViewLoginActivity : BaseStatusActivity() {
         binding!!.loginByWebWebview.webViewClient = cookieWebViewClientInstance!!
     }
 
-    fun configureQQLoginWebview(url: String) {
+    fun configureQQLoginWebview(url: String, savedInstanceState: Bundle? = null) {
         cookieWebViewClientInstance = CookieWebViewClient()
         Log.d(TAG, "login qq url $url")
-        binding!!.loginByWebWebview.loadUrl(url)
+        if (savedInstanceState != null) {
+            binding!!.loginByWebWebview.restoreState(savedInstanceState)
+        } else {
+            binding!!.loginByWebWebview.loadUrl(url)
+        }
 
 
         // binding.loginByWebWebview.clearCache(true);

--- a/app/src/main/java/com/kidozh/discuzhub/activities/WebViewLoginActivity.kt
+++ b/app/src/main/java/com/kidozh/discuzhub/activities/WebViewLoginActivity.kt
@@ -50,19 +50,9 @@ class WebViewLoginActivity : BaseStatusActivity() {
             layoutInflater
         )
         setContentView(binding!!.root)
-        configureIntentData(savedInstanceState)
+        configureIntentData()
         configureActionBar()
-        if (savedInstanceState == null) {
-            configureAlertDialog()
-        }
-    }
-
-    override fun onSaveInstanceState(outState: Bundle) {
-        super.onSaveInstanceState(outState)
-        // Issue #46: persist the login WebView so device rotation does
-        // not drop the user back at the initial login page after they
-        // have already navigated several screens deep.
-        binding?.loginByWebWebview?.saveState(outState)
+        configureAlertDialog()
     }
 
     fun configureAlertDialog() {
@@ -73,18 +63,18 @@ class WebViewLoginActivity : BaseStatusActivity() {
             .show()
     }
 
-    fun configureIntentData() {
+    fun configureIntentData(savedInstanceState: Bundle? = null) {
         val intent = intent
         discuz = intent.getSerializableExtra(ConstUtils.PASS_BBS_ENTITY_KEY) as Discuz?
         if (discuz != null) {
             URLUtils.setBBS(discuz)
-            configureWebView()
+            configureWebView(savedInstanceState)
         } else {
             // judge whether from QQ
             if (Intent.ACTION_VIEW == intent.action && intent.data != null) {
                 val url = intent.data.toString()
                 Log.d(TAG, "Get QQ Login URL $url")
-                configureQQLoginWebview(url)
+                configureQQLoginWebview(url, savedInstanceState)
             }
         }
     }


### PR DESCRIPTION
Closes #46.

Rotating the device while the login WebView has navigated several pages deep snapped the page back to the initial login URL. The activity rebuilt the WebView and called `loadUrl` unconditionally on every recreate.

This change persists the WebView via `onSaveInstanceState` and restores it on recreate, falling back to the initial load when there is no snapshot. The QQ-login path gets the same treatment for consistency.

```kotlin
override fun onSaveInstanceState(outState: Bundle) {
    super.onSaveInstanceState(outState)
    binding?.loginByWebWebview?.saveState(outState)
}
```

```kotlin
if (savedInstanceState != null) {
    binding!!.loginByWebWebview.restoreState(savedInstanceState)
} else {
    binding!!.loginByWebWebview.loadUrl(URLUtils.getLoginWebURL(discuz!!))
    binding!!.loginByWebWebview.clearCache(true)
}
```
