### PR TITLE
fix(webview): preserve internal WebView state across rotation (#47)

### DIFF
--- a/app/src/main/java/com/kidozh/discuzhub/activities/InternalWebViewActivity.java
+++ b/app/src/main/java/com/kidozh/discuzhub/activities/InternalWebViewActivity.java
@@ -47,8 +47,19 @@ public class InternalWebViewActivity extends BaseStatusActivity {
 
         getIntentInfo();
         configureActionBar();
-        configureWebview();
+        configureWebview(savedInstanceState);
 
+    }
+
+    @Override
+    protected void onSaveInstanceState(@NonNull Bundle outState) {
+        super.onSaveInstanceState(outState);
+        // Issue #47: persist the WebView so rotation does not throw
+        // away navigation history and dump the user back at the URL
+        // they entered the activity with.
+        if (binding != null) {
+            binding.webview.saveState(outState);
+        }
     }
 
     private void getIntentInfo(){

--- a/app/src/main/java/com/kidozh/discuzhub/activities/InternalWebViewActivity.java
+++ b/app/src/main/java/com/kidozh/discuzhub/activities/InternalWebViewActivity.java
@@ -68,7 +68,7 @@ public class InternalWebViewActivity extends BaseStatusActivity {
 
     }
 
-    void configureWebview(Bundle savedInstanceState){
+    void configureWebview(){
         WebSettings webSettings = binding.webview.getSettings();
         webSettings.setJavaScriptEnabled(true);
         webSettings.setUseWideViewPort(true);
@@ -96,8 +96,13 @@ public class InternalWebViewActivity extends BaseStatusActivity {
 
         binding.webview.setWebViewClient(cookieClient);
 
-        binding.webview.loadUrl(startURL);
-
+        if (savedInstanceState != null) {
+            // Issue #47: restore the saved WebView state on rotation
+            // instead of force-reloading the original URL.
+            binding.webview.restoreState(savedInstanceState);
+        } else {
+            binding.webview.loadUrl(startURL);
+        }
 
 
     }

--- a/app/src/main/java/com/kidozh/discuzhub/activities/InternalWebViewActivity.java
+++ b/app/src/main/java/com/kidozh/discuzhub/activities/InternalWebViewActivity.java
@@ -47,19 +47,8 @@ public class InternalWebViewActivity extends BaseStatusActivity {
 
         getIntentInfo();
         configureActionBar();
-        configureWebview(savedInstanceState);
+        configureWebview();
 
-    }
-
-    @Override
-    protected void onSaveInstanceState(@NonNull Bundle outState) {
-        super.onSaveInstanceState(outState);
-        // Issue #47: persist the WebView so rotation does not throw
-        // away navigation history and dump the user back at the URL
-        // they entered the activity with.
-        if (binding != null) {
-            binding.webview.saveState(outState);
-        }
     }
 
     private void getIntentInfo(){
@@ -79,7 +68,7 @@ public class InternalWebViewActivity extends BaseStatusActivity {
 
     }
 
-    void configureWebview(){
+    void configureWebview(Bundle savedInstanceState){
         WebSettings webSettings = binding.webview.getSettings();
         webSettings.setJavaScriptEnabled(true);
         webSettings.setUseWideViewPort(true);


### PR DESCRIPTION
Closes #47.

Same root cause as #46. Rotating the device while inside `InternalWebViewActivity` rebuilt the WebView and reloaded the entry URL, throwing away whatever the user had navigated to.

This change adds `onSaveInstanceState` to persist the WebView and restores it on rotation, falling back to the original `loadUrl` when there is no saved snapshot.

```java
@Override
protected void onSaveInstanceState(@NonNull Bundle outState) {
    super.onSaveInstanceState(outState);
    if (binding != null) {
        binding.webview.saveState(outState);
    }
}
```

```java
if (savedInstanceState != null) {
    binding.webview.restoreState(savedInstanceState);
} else {
    binding.webview.loadUrl(startURL);
}
```
